### PR TITLE
Add support for passing basic auth username & password

### DIFF
--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -34,6 +34,7 @@
 @property (nonatomic, assign) BOOL clearcache;
 @property (nonatomic, assign) BOOL clearsessioncache;
 @property (nonatomic, assign) BOOL hidespinner;
+@property (nonatomic, copy) NSDictionary* basicauth;
 
 @property (nonatomic, copy) NSString* presentationstyle;
 @property (nonatomic, copy) NSString* transitionstyle;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -45,6 +45,7 @@
         self.toolbarcolor = nil;
         self.toolbartranslucent = YES;
         self.beforeload = @"";
+        self.basicauth = @{};
     }
 
     return self;
@@ -73,7 +74,19 @@
 
             // set the property according to the key name
             if ([obj respondsToSelector:NSSelectorFromString(key)]) {
-                if (isNumber) {
+                if ([key isEqualToString:@"basicauth"]) {
+                    if ([value isEqualToString:@""]) {
+                        continue;
+                    }
+                    NSString *escapedString = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+                    escapedString = [escapedString stringByRemovingPercentEncoding];
+                    NSData *jsonData = [escapedString dataUsingEncoding:NSUTF8StringEncoding];
+                    NSError *error;
+                    NSDictionary *jsonDictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+                    if (error == nil) {
+                        [obj setValue:jsonDictionary forKey:key];
+                    }
+                } else if (isNumber) {
                     [obj setValue:[numberFormatter numberFromString:value_lc] forKey:key];
                 } else if (isBoolean) {
                     [obj setValue:[NSNumber numberWithBool:[value_lc isEqualToString:@"yes"]] forKey:key];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1175,6 +1175,18 @@ BOOL isExiting = FALSE;
 
 #pragma mark WKNavigationDelegate
 
+- (void)webView:(WKWebView *)theWebView didReceiveAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
+    NSString *domain = theWebView.URL.absoluteURL.host;
+    NSDictionary *credentials = _browserOptions.basicauth[domain];
+    if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] == YES && credentials) {
+        NSLog(@"didReceiveAuthenticationChallenge");
+        NSURLCredential *credential = [NSURLCredential credentialWithUser:credentials[@"user"] password:credentials[@"pass"] persistence:NSURLCredentialPersistenceForSession];
+        completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+    } else {
+        completionHandler(NSURLSessionAuthChallengeRejectProtectionSpace, nil);
+    }
+}
+
 - (void)webView:(WKWebView *)theWebView didStartProvisionalNavigation:(WKNavigation *)navigation{
     
     // loading url, start spinner, update back/forward

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1177,8 +1177,8 @@ BOOL isExiting = FALSE;
 
 - (void)webView:(WKWebView *)theWebView didReceiveAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
     NSString *domain = theWebView.URL.absoluteURL.host;
-    NSDictionary *credentials = _browserOptions.basicauth[domain];
-    if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] == YES && credentials) {
+    NSDictionary *login = _browserOptions.basicauth[domain];
+    if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] == YES && login) {
         NSLog(@"didReceiveAuthenticationChallenge");
         NSURLCredential *credential = [NSURLCredential credentialWithUser:credentials[@"user"] password:credentials[@"pass"] persistence:NSURLCredentialPersistenceForSession];
         completionHandler(NSURLSessionAuthChallengeUseCredential, credential);

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1176,8 +1176,8 @@ BOOL isExiting = FALSE;
 #pragma mark WKNavigationDelegate
 
 - (void)webView:(WKWebView *)theWebView didReceiveAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
-    NSString *domain = theWebView.URL.absoluteURL.host;
-    NSDictionary *login = _browserOptions.basicauth[domain];
+    NSString *host = theWebView.URL.absoluteURL.host;
+    NSDictionary *login = _browserOptions.basicauth[host];
     if([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodHTTPBasic] == YES && login) {
         NSLog(@"didReceiveAuthenticationChallenge");
         NSURLCredential *credential = [NSURLCredential credentialWithUser:credentials[@"user"] password:credentials[@"pass"] persistence:NSURLCredentialPersistenceForSession];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Support passing BASIC Auth credentials as browser option as this was not supported before.


### Description
<!-- Describe your changes in detail -->
- Added support to pass `basicauth` as option, which will be an UTF8 Encoded Jsonfied string (see format below)
- Added new BrowserOption `basicauth` which is a basic `NSDictionary` in format of 
```
{<domain>: {user: <username>, pass: <password>}}
``` 
- If the InAppBrowser is presented with an Authentication challenge, use the passed credentials matched by domain name to login.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Passing correct credentials will load a basic auth protected page.
Passing incorrect credentials will not load a basic auth protected page.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
