### PR TITLE
Support append user agent as browseroption on iOS and Android

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -131,6 +131,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FULLSCREEN = "fullscreen";
     private static final String BASICAUTH = "basicauth";
     private static final String HEADERS = "headers";
+    private static final String APPEND_USER_AGENT = "appenduseragent";
 
     private static final int TOOLBAR_HEIGHT = 48;
 
@@ -144,6 +145,7 @@ public class InAppBrowser extends CordovaPlugin {
             NAVIGATION_COLOR,
             FOOTER_COLOR,
             BASICAUTH,
+            APPEND_USER_AGENT,
             HEADERS);
 
     private static final List urlEncodedOptions = Arrays.asList(BASICAUTH, HEADERS);
@@ -179,6 +181,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean fullscreen = true;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
+    private String appendUserAgent = "";
 
     private class BasicAuthLogin {
         public String user;
@@ -835,6 +838,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (headersSet != null) {
                 additionalHeaders = new Gson().fromJson(headersSet, additionalHeadersType);
             }
+            String appendUserAgentSet = features.get(APPEND_USER_AGENT);
+            if (appendUserAgentSet != null) {
+                appendUserAgent = appendUserAgentSet;
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -1111,13 +1118,16 @@ public class InAppBrowser extends CordovaPlugin {
                 settings.setMediaPlaybackRequiresUserGesture(mediaPlaybackRequiresUserGesture);
                 inAppWebView.addJavascriptInterface(new JsObject(), "cordova_iab");
 
-                String overrideUserAgent = preferences.getString("OverrideUserAgent", null);
-                String appendUserAgent = preferences.getString("AppendUserAgent", null);
+                String overrideUserAgentPreference = preferences.getString("OverrideUserAgent", null);
+                String appendUserAgentPreference = preferences.getString("AppendUserAgent", null);
 
-                if (overrideUserAgent != null) {
-                    settings.setUserAgentString(overrideUserAgent);
+                if (overrideUserAgentPreference != null) {
+                    settings.setUserAgentString(overrideUserAgentPreference);
                 }
-                if (appendUserAgent != null) {
+                if (appendUserAgentPreference != null) {
+                    settings.setUserAgentString(settings.getUserAgentString() + " " + appendUserAgentPreference);
+                }
+                if (appendUserAgent != null && !appendUserAgent.isEmpty()) {
                     settings.setUserAgentString(settings.getUserAgentString() + " " + appendUserAgent);
                 }
 

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -46,6 +46,7 @@
 @property (nonatomic, assign) BOOL hidden;
 @property (nonatomic, assign) BOOL disallowoverscroll;
 @property (nonatomic, copy) NSString* beforeload;
+@property (nonatomic, copy) NSString* appenduseragent;
 
 @property (nonatomic, copy) NSDictionary* basicauth;
 @property (nonatomic, copy) NSArray* headers;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -45,6 +45,7 @@
         self.toolbarcolor = nil;
         self.toolbartranslucent = YES;
         self.beforeload = @"";
+        self.appenduseragent = @"";
 
         self.basicauth = @{};
         self.headers = @[];

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -746,6 +746,9 @@ BOOL isExiting = FALSE;
         [self settingForKey:@"AppendUserAgent"] != nil) {
         userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, [self settingForKey:@"AppendUserAgent"]];
     }
+    if (![_browserOptions.appenduseragent isEqualToString:@""]) {
+        userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, _browserOptions.appenduseragent];
+    }
     configuration.applicationNameForUserAgent = userAgent;
     configuration.userContentController = userContentController;
 #if __has_include(<Cordova/CDVWebViewProcessPoolFactory.h>)

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -746,7 +746,7 @@ BOOL isExiting = FALSE;
         [self settingForKey:@"AppendUserAgent"] != nil) {
         userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, [self settingForKey:@"AppendUserAgent"]];
     }
-    if (![_browserOptions.appenduseragent isEqualToString:@""]) {
+    if ([_browserOptions.appenduseragent length] > 0) {
         userAgent = [NSString stringWithFormat:@"%@ %@", userAgent, _browserOptions.appenduseragent];
     }
     configuration.applicationNameForUserAgent = userAgent;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android & iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Supporting append-user-agent to be passed as a browser option instead of preference to easily be used from capacitor plugin.


### Description
Added support to pass `appenduseragent` option to be passed which as the name implies, will be appended to the user-agent header.


### Testing
Linking and building both on iOS and Android

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
